### PR TITLE
fix: pin the actions, remove npm publish token

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,13 +6,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm publish --access public
         if: ${{ !env.ACT }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_PUBLIC_PUBLISH }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,11 +6,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
+
       - run: npm ci
+
       - run: npm publish --access public
         if: ${{ !env.ACT }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2.1.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
     - name: Set up Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
-        node-version: 16.17.0
+        node-version: '24.x'
     - run: npm install
     - run: npm run asbuild
     # make sure example filter builds:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,8 +15,10 @@ jobs:
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version: '24.x'
-    - run: npm install
-    - run: npm run asbuild
+    - run: |
+        npm --version
+        npm install
+        npm run asbuild
     # make sure example filter builds:
     - run: cd examples/auth && npm install && npm run asbuild
     - run: cd examples/addheader && npm install && npm run asbuild


### PR DESCRIPTION
# Summary

- pin the actions used in workflows
- bump the node to use npm version capable of oidc trusted publishing
- remove references to NPM_TOKEN_PUBLIC_PUBLISH
- added branch protection rules for `master`

trusted publishing for this package is set on npmjs.com as : 

<img width="811" height="556" alt="image" src="https://github.com/user-attachments/assets/51678d54-f816-498c-82c6-942408bf122f" />
